### PR TITLE
Rename joint_group 'head' to 'neck' to be consistent with Amigo

### DIFF
--- a/custom/joint_groups.yaml
+++ b/custom/joint_groups.yaml
@@ -50,9 +50,9 @@ robot_joint_groups:
           - hip_joint
       parameter_file_package: "sergio_controller_configuration_gazebo"
       parameter_file_path: "/parameters/torso_controller.yaml"
-    - name: head
-      reference_topic: "/sergio/head/references"
-      measurement_topic: "/sergio/head/measurements"
+    - name: neck
+      reference_topic: "/sergio/neck/references"
+      measurement_topic: "/sergio/neck/measurements"
       joint_names:
           - neck_pan_joint
           - neck_tilt_joint


### PR DESCRIPTION
This, together with
https://github.com/tue-robotics/head_ref/tree/refactor/use-joint-trajectory-action-interface
(https://github.com/tue-robotics/head_ref/pull/9) allows to control the
head from sergio-console:

```python
sergio.head.look_at_standing_person()
sergio.head.look_at_ground_in_front_of_robot()
```